### PR TITLE
Added small validation to ensure the popup shows up at the right moment.

### DIFF
--- a/Sources/AppReview/AppReview.swift
+++ b/Sources/AppReview/AppReview.swift
@@ -61,6 +61,12 @@ public class AppReview {
 
     @discardableResult
     public func requestIfNeeded() -> Bool {
+        
+        guard !isDebugConfig else {
+            request()
+            return true
+        }
+        
         if firstLaunchDate == nil { firstLaunchDate = Date() }
         launches += 1
         guard isNeeded else { return false }
@@ -92,6 +98,14 @@ public class AppReview {
     
     internal func daysBetween(_ start: Date, _ end: Date) -> Int {
         Calendar.current.dateComponents([.day], from: start, to: end).day!
+    }
+    
+    internal func isDebugConfig -> Bool {
+#if DEBUG
+        return true
+#else
+        return false
+#endif
     }
     
 }


### PR DESCRIPTION
Because the rating prompt will always show up when a debugger is attached, I added an small validation to shows up when the app is running on DEBUG configuration